### PR TITLE
fix(provider):fix local fs deal list error

### DIFF
--- a/storage/provider/localfs_provider_test.go
+++ b/storage/provider/localfs_provider_test.go
@@ -1,0 +1,505 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLocalFSProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *ProviderConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config with default values",
+			config: &ProviderConfig{
+				Type: ProviderTypeLocalFS,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with custom base path",
+			config: &ProviderConfig{
+				Type: ProviderTypeLocalFS,
+				LocalFS: &LocalFSConfig{
+					BasePath:   "./test-data",
+					CreateDirs: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with custom permissions",
+			config: &ProviderConfig{
+				Type: ProviderTypeLocalFS,
+				LocalFS: &LocalFSConfig{
+					BasePath:    "./test-data",
+					CreateDirs:  true,
+					Permissions: "0755",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid provider type",
+			config: &ProviderConfig{
+				Type: ProviderTypeS3,
+			},
+			wantErr: true,
+			errMsg:  "invalid provider type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for testing
+			tempDir := t.TempDir()
+			if tt.config.LocalFS != nil {
+				tt.config.LocalFS.BasePath = filepath.Join(tempDir, tt.config.LocalFS.BasePath)
+			} else if !tt.wantErr {
+				tt.config.LocalFS = &LocalFSConfig{
+					BasePath: filepath.Join(tempDir, "metering-data"),
+				}
+			}
+
+			provider, err := NewLocalFSProvider(tt.config)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				assert.Nil(t, provider)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, provider)
+				assert.Equal(t, tt.config.LocalFS.BasePath, provider.basePath)
+			}
+		})
+	}
+}
+
+func TestLocalFSProvider_Upload_Download(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	config := &ProviderConfig{
+		Type: ProviderTypeLocalFS,
+		LocalFS: &LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	provider, err := NewLocalFSProvider(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "upload and download simple file",
+			path:    "test/file1.txt",
+			content: "Hello, World!",
+			wantErr: false,
+		},
+		{
+			name:    "upload and download nested path",
+			path:    "deep/nested/path/file.json",
+			content: `{"key": "value", "number": 123}`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Upload
+			reader := strings.NewReader(tt.content)
+			err := provider.Upload(ctx, tt.path, reader)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Test Download
+			downloadReader, err := provider.Download(ctx, tt.path)
+			assert.NoError(t, err)
+			assert.NotNil(t, downloadReader)
+
+			// Read the downloaded content
+			downloadedContent, err := io.ReadAll(downloadReader)
+			assert.NoError(t, err)
+			downloadReader.Close()
+
+			// Verify content matches
+			assert.Equal(t, tt.content, string(downloadedContent))
+
+			// Verify file exists on filesystem
+			fullPath := filepath.Join(tempDir, tt.path)
+			_, err = os.Stat(fullPath)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestLocalFSProvider_WithPrefix(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	config := &ProviderConfig{
+		Type:   ProviderTypeLocalFS,
+		Prefix: "data/metrics",
+		LocalFS: &LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	provider, err := NewLocalFSProvider(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	testPath := "test.txt"
+	testContent := "test content with prefix"
+
+	// Upload file
+	reader := strings.NewReader(testContent)
+	err = provider.Upload(ctx, testPath, reader)
+	assert.NoError(t, err)
+
+	// Verify file was created in the correct location with prefix
+	expectedPath := filepath.Join(tempDir, "data", "metrics", testPath)
+	_, err = os.Stat(expectedPath)
+	assert.NoError(t, err)
+
+	// Download and verify content
+	downloadReader, err := provider.Download(ctx, testPath)
+	assert.NoError(t, err)
+	downloadedContent, err := io.ReadAll(downloadReader)
+	assert.NoError(t, err)
+	downloadReader.Close()
+	assert.Equal(t, testContent, string(downloadedContent))
+}
+
+func TestLocalFSProvider_Exists(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	config := &ProviderConfig{
+		Type: ProviderTypeLocalFS,
+		LocalFS: &LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	provider, err := NewLocalFSProvider(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Test non-existent file
+	exists, err := provider.Exists(ctx, "non-existent.txt")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	// Upload a file
+	testPath := "exists-test.txt"
+	testContent := "test content"
+	reader := strings.NewReader(testContent)
+	err = provider.Upload(ctx, testPath, reader)
+	assert.NoError(t, err)
+
+	// Test existing file
+	exists, err = provider.Exists(ctx, testPath)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestLocalFSProvider_Delete(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	config := &ProviderConfig{
+		Type: ProviderTypeLocalFS,
+		LocalFS: &LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	provider, err := NewLocalFSProvider(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Upload a file first
+	testPath := "delete-test.txt"
+	testContent := "test content for deletion"
+	reader := strings.NewReader(testContent)
+	err = provider.Upload(ctx, testPath, reader)
+	assert.NoError(t, err)
+
+	// Verify file exists
+	exists, err := provider.Exists(ctx, testPath)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// Delete the file
+	err = provider.Delete(ctx, testPath)
+	assert.NoError(t, err)
+
+	// Verify file no longer exists
+	exists, err = provider.Exists(ctx, testPath)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
+	// Test deleting non-existent file (should not error)
+	err = provider.Delete(ctx, "non-existent.txt")
+	assert.NoError(t, err)
+}
+
+func TestLocalFSProvider_List(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	config := &ProviderConfig{
+		Type: ProviderTypeLocalFS,
+		LocalFS: &LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	provider, err := NewLocalFSProvider(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Upload multiple test files
+	testFiles := map[string]string{
+		"logs/2023/01/app.log":   "log content 1",
+		"logs/2023/02/app.log":   "log content 2",
+		"logs/2023/02/error.log": "error log content",
+		"metrics/cpu.json":       `{"cpu": 80}`,
+		"metrics/memory.json":    `{"memory": 70}`,
+		"config.yml":             "config content",
+	}
+
+	for path, content := range testFiles {
+		reader := strings.NewReader(content)
+		err := provider.Upload(ctx, path, reader)
+		assert.NoError(t, err)
+	}
+
+	tests := []struct {
+		name             string
+		prefix           string
+		expectedMin      int // minimum expected files (due to path separator normalization)
+		expectedContains []string
+	}{
+		{
+			name:             "list all files",
+			prefix:           "",
+			expectedMin:      6,
+			expectedContains: []string{"config.yml", "logs/2023/01/app.log", "metrics/cpu.json"},
+		},
+		{
+			name:             "list logs only",
+			prefix:           "logs",
+			expectedMin:      3,
+			expectedContains: []string{"logs/2023/01/app.log", "logs/2023/02/app.log", "logs/2023/02/error.log"},
+		},
+		{
+			name:             "list specific log directory",
+			prefix:           "logs/2023/02",
+			expectedMin:      2,
+			expectedContains: []string{"logs/2023/02/app.log", "logs/2023/02/error.log"},
+		},
+		{
+			name:             "list metrics only",
+			prefix:           "metrics",
+			expectedMin:      2,
+			expectedContains: []string{"metrics/cpu.json", "metrics/memory.json"},
+		},
+		{
+			name:             "list non-existent prefix",
+			prefix:           "non-existent",
+			expectedMin:      0,
+			expectedContains: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files, err := provider.List(ctx, tt.prefix)
+			assert.NoError(t, err)
+			assert.GreaterOrEqual(t, len(files), tt.expectedMin)
+
+			// Check that expected files are in the result
+			for _, expectedFile := range tt.expectedContains {
+				found := false
+				for _, file := range files {
+					if file == expectedFile {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected file %s not found in list result", expectedFile)
+			}
+
+			// Verify all returned files have the correct prefix
+			for _, file := range files {
+				if tt.prefix != "" {
+					assert.True(t, strings.HasPrefix(file, tt.prefix),
+						"File %s does not have expected prefix %s", file, tt.prefix)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalFSProvider_Download_NonExistentFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	config := &ProviderConfig{
+		Type: ProviderTypeLocalFS,
+		LocalFS: &LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	provider, err := NewLocalFSProvider(config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Try to download non-existent file
+	_, err = provider.Download(ctx, "non-existent.txt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file not found")
+}
+
+func TestParseFileMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		perm     string
+		expected os.FileMode
+		wantErr  bool
+	}{
+		{
+			name:     "valid octal permission",
+			perm:     "0755",
+			expected: 0755,
+			wantErr:  false,
+		},
+		{
+			name:     "valid octal permission 644",
+			perm:     "0644",
+			expected: 0644,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid permission format",
+			perm:     "755",
+			expected: 0755,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid octal format",
+			perm:     "0abc",
+			expected: 0755,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseFileMode(tt.perm)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestLocalFSProvider_BuildPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		prefix   string
+		path     string
+		expected string
+	}{
+		{
+			name:     "no prefix",
+			prefix:   "",
+			path:     "test.txt",
+			expected: filepath.Join(tempDir, "test.txt"),
+		},
+		{
+			name:     "with prefix",
+			prefix:   "data",
+			path:     "test.txt",
+			expected: filepath.Join(tempDir, "data", "test.txt"),
+		},
+		{
+			name:     "prefix with trailing separator",
+			prefix:   "data/",
+			path:     "test.txt",
+			expected: filepath.Join(tempDir, "data", "test.txt"),
+		},
+		{
+			name:     "path with leading separator",
+			prefix:   "data",
+			path:     "/test.txt",
+			expected: filepath.Join(tempDir, "data", "test.txt"),
+		},
+		{
+			name:     "nested path",
+			prefix:   "data/metrics",
+			path:     "cpu/usage.json",
+			expected: filepath.Join(tempDir, "data", "metrics", "cpu", "usage.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &ProviderConfig{
+				Type:   ProviderTypeLocalFS,
+				Prefix: tt.prefix,
+				LocalFS: &LocalFSConfig{
+					BasePath: tempDir,
+				},
+			}
+
+			provider, err := NewLocalFSProvider(config)
+			require.NoError(t, err)
+
+			result := provider.buildPath(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/pingcap/metering_sdk/common"
 	"github.com/pingcap/metering_sdk/config"
-	"github.com/pingcap/metering_sdk/storage"
 	metareader "github.com/pingcap/metering_sdk/reader/meta"
 	meteringreader "github.com/pingcap/metering_sdk/reader/metering"
+	"github.com/pingcap/metering_sdk/storage"
 	metawriter "github.com/pingcap/metering_sdk/writer/meta"
 	meteringwriter "github.com/pingcap/metering_sdk/writer/metering"
 	"github.com/stretchr/testify/assert"
@@ -474,7 +474,7 @@ func TestMeteringReaderWithLocalFS(t *testing.T) {
 		for i, dataEntry := range readData.Data {
 			originalEntry := testData.Data[i]
 			assert.Equal(t, originalEntry["logical_cluster"], dataEntry["logical_cluster"], "Logical cluster mismatch")
-			
+
 			// Check metering values
 			if originalCPU, ok := originalEntry["cpu_usage"].(*common.MeteringValue); ok {
 				if readCPU, ok := dataEntry["cpu_usage"].(map[string]interface{}); ok {
@@ -494,7 +494,7 @@ func TestMeteringReaderWithLocalFS(t *testing.T) {
 		firstStorageFile := storageFiles[0]
 		readInterface, err := meteringReader.Read(context.Background(), firstStorageFile)
 		assert.NoError(t, err, "Failed to read file via interface %s", firstStorageFile)
-		
+
 		readData, ok := readInterface.(*common.MeteringData)
 		assert.True(t, ok, "Read interface should return *common.MeteringData")
 		assert.Equal(t, testTimestamp, readData.Timestamp, "Interface read data timestamp mismatch")
@@ -516,7 +516,7 @@ func TestMeteringReaderWithLocalFS(t *testing.T) {
 	_, err = meteringReader.GetFileInfo("invalid/path")
 	assert.Error(t, err, "Should error for invalid file path")
 
-	t.Logf("Metering reader test passed. Files found: compute=%d, storage=%d", 
+	t.Logf("Metering reader test passed. Files found: compute=%d, storage=%d",
 		len(computeFiles), len(storageFiles))
 }
 
@@ -571,7 +571,7 @@ func TestMeteringReadWriteRoundtripWithLocalFS(t *testing.T) {
 				{
 					"logical_cluster": "production",
 					"disk_size":       &common.MeteringValue{Value: 1000, Unit: "GB"},
-					"iops":           &common.MeteringValue{Value: 5000, Unit: "ops/s"},
+					"iops":            &common.MeteringValue{Value: 5000, Unit: "ops/s"},
 				},
 			},
 		},
@@ -751,7 +751,7 @@ func TestMetaReaderWithLocalFS(t *testing.T) {
 	metaReader, err := metareader.NewMetaReader(provider, cfg, nil)
 	assert.NoError(t, err, "Failed to create meta reader")
 
-	// Test Read - read metadata by cluster ID and timestamp  
+	// Test Read - read metadata by cluster ID and timestamp
 	firstMeta, err := metaReader.Read(context.Background(), testClusterID, testTimestamp)
 	assert.NoError(t, err, "Failed to read metadata by timestamp")
 	assert.NotNil(t, firstMeta, "First metadata should not be nil")
@@ -791,6 +791,6 @@ func TestMetaReaderWithLocalFS(t *testing.T) {
 	_, err = metaReader.ReadFile(context.Background(), "metering/meta/non-existent/999999.json.gz")
 	assert.Error(t, err, "Should error when reading non-existent file")
 
-	t.Logf("Meta reader test passed. Cluster: %s, Timestamps: [%d, %d]", 
+	t.Logf("Meta reader test passed. Cluster: %s, Timestamps: [%d, %d]",
 		testClusterID, testTimestamp, testTimestamp+60)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pingcap/metering_sdk/common"
 	"github.com/pingcap/metering_sdk/config"
 	"github.com/pingcap/metering_sdk/storage"
+	metareader "github.com/pingcap/metering_sdk/reader/meta"
+	meteringreader "github.com/pingcap/metering_sdk/reader/metering"
 	metawriter "github.com/pingcap/metering_sdk/writer/meta"
 	meteringwriter "github.com/pingcap/metering_sdk/writer/metering"
 	"github.com/stretchr/testify/assert"
@@ -353,4 +355,442 @@ func TestS3ProviderPrefix(t *testing.T) {
 				tt.prefix, tt.bucket, tt.region)
 		})
 	}
+}
+
+func TestMeteringReaderWithLocalFS(t *testing.T) {
+	// Create temporary directory
+	tempDir := filepath.Join(os.TempDir(), "tidb-metering-test", "reader")
+	defer os.RemoveAll(tempDir)
+
+	// Create configuration
+	cfg := config.DefaultConfig()
+	providerConfig := &storage.ProviderConfig{
+		Type: storage.ProviderTypeLocalFS,
+		LocalFS: &storage.LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	// Create storage provider
+	provider, err := storage.NewObjectStorageProvider(providerConfig)
+	assert.NoError(t, err, "Failed to create LocalFS provider")
+
+	// First write some test data using the writer
+	meteringWriter := meteringwriter.NewMeteringWriter(provider, cfg)
+	defer meteringWriter.Close()
+
+	// Create test data
+	testTimestamp := int64(1640995200) // 2022-01-01 00:00:00 UTC
+	testData := &common.MeteringData{
+		Timestamp: testTimestamp,
+		Category:  "compute",
+		SelfID:    "cluster001",
+		Data: []map[string]interface{}{
+			{
+				"logical_cluster": "lc-test-1",
+				"cpu_usage":       &common.MeteringValue{Value: 80, Unit: "percentage"},
+				"memory_usage":    &common.MeteringValue{Value: 2048, Unit: "MB"},
+			},
+			{
+				"logical_cluster": "lc-test-2",
+				"cpu_usage":       &common.MeteringValue{Value: 60, Unit: "percentage"},
+				"memory_usage":    &common.MeteringValue{Value: 1024, Unit: "MB"},
+			},
+		},
+	}
+
+	// Write test data
+	err = meteringWriter.Write(context.Background(), testData)
+	assert.NoError(t, err, "Failed to write test data")
+
+	// Create another test data with different category
+	testData2 := &common.MeteringData{
+		Timestamp: testTimestamp,
+		Category:  "storage",
+		SelfID:    "storage001",
+		Data: []map[string]interface{}{
+			{
+				"logical_cluster": "lc-test-1",
+				"disk_usage":      &common.MeteringValue{Value: 500, Unit: "GB"},
+			},
+		},
+	}
+
+	// Write second test data
+	err = meteringWriter.Write(context.Background(), testData2)
+	assert.NoError(t, err, "Failed to write second test data")
+
+	// Now test the reader
+	meteringReader := meteringreader.NewMeteringReader(provider, cfg)
+
+	// Test ListFilesByTimestamp
+	timestampFiles, err := meteringReader.ListFilesByTimestamp(context.Background(), testTimestamp)
+	assert.NoError(t, err, "Failed to list files by timestamp")
+	assert.NotNil(t, timestampFiles, "TimestampFiles should not be nil")
+	assert.Equal(t, testTimestamp, timestampFiles.Timestamp, "Timestamp mismatch")
+	assert.Contains(t, timestampFiles.Files, "compute", "Compute category should exist")
+	assert.Contains(t, timestampFiles.Files, "storage", "Storage category should exist")
+	assert.Greater(t, len(timestampFiles.Files["compute"]), 0, "Compute category should have files")
+	assert.Greater(t, len(timestampFiles.Files["storage"]), 0, "Storage category should have files")
+
+	// Test GetCategories
+	categories, err := meteringReader.GetCategories(context.Background(), testTimestamp)
+	assert.NoError(t, err, "Failed to get categories")
+	assert.Contains(t, categories, "compute", "Categories should contain compute")
+	assert.Contains(t, categories, "storage", "Categories should contain storage")
+
+	// Test GetFilesByCategory
+	computeFiles, err := meteringReader.GetFilesByCategory(context.Background(), testTimestamp, "compute")
+	assert.NoError(t, err, "Failed to get compute files")
+	assert.Greater(t, len(computeFiles), 0, "Should have compute files")
+
+	storageFiles, err := meteringReader.GetFilesByCategory(context.Background(), testTimestamp, "storage")
+	assert.NoError(t, err, "Failed to get storage files")
+	assert.Greater(t, len(storageFiles), 0, "Should have storage files")
+
+	// Test GetFileInfo
+	for _, filePath := range computeFiles {
+		fileInfo, err := meteringReader.GetFileInfo(filePath)
+		assert.NoError(t, err, "Failed to get file info for %s", filePath)
+		assert.Equal(t, testTimestamp, fileInfo.Timestamp, "File timestamp mismatch")
+		assert.Equal(t, "compute", fileInfo.Category, "File category mismatch")
+		assert.Equal(t, "cluster001", fileInfo.SelfID, "File self_id mismatch")
+		assert.GreaterOrEqual(t, fileInfo.Part, 0, "File part should be non-negative")
+	}
+
+	// Test ReadFile
+	if len(computeFiles) > 0 {
+		firstComputeFile := computeFiles[0]
+		readData, err := meteringReader.ReadFile(context.Background(), firstComputeFile)
+		assert.NoError(t, err, "Failed to read file %s", firstComputeFile)
+		assert.NotNil(t, readData, "Read data should not be nil")
+		assert.Equal(t, testTimestamp, readData.Timestamp, "Read data timestamp mismatch")
+		assert.Equal(t, "compute", readData.Category, "Read data category mismatch")
+		assert.Equal(t, "cluster001", readData.SelfID, "Read data self_id mismatch")
+		assert.Equal(t, len(testData.Data), len(readData.Data), "Data entries count mismatch")
+
+		// Verify data content
+		for i, dataEntry := range readData.Data {
+			originalEntry := testData.Data[i]
+			assert.Equal(t, originalEntry["logical_cluster"], dataEntry["logical_cluster"], "Logical cluster mismatch")
+			
+			// Check metering values
+			if originalCPU, ok := originalEntry["cpu_usage"].(*common.MeteringValue); ok {
+				if readCPU, ok := dataEntry["cpu_usage"].(map[string]interface{}); ok {
+					// JSON unmarshaling converts numbers to float64, so we need to compare accordingly
+					expectedValue := float64(originalCPU.Value)
+					assert.Equal(t, expectedValue, readCPU["value"], "CPU value mismatch")
+					assert.Equal(t, originalCPU.Unit, readCPU["unit"], "CPU unit mismatch")
+				} else {
+					t.Errorf("CPU usage data format unexpected: %+v", dataEntry["cpu_usage"])
+				}
+			}
+		}
+	}
+
+	// Test Read (interface method)
+	if len(storageFiles) > 0 {
+		firstStorageFile := storageFiles[0]
+		readInterface, err := meteringReader.Read(context.Background(), firstStorageFile)
+		assert.NoError(t, err, "Failed to read file via interface %s", firstStorageFile)
+		
+		readData, ok := readInterface.(*common.MeteringData)
+		assert.True(t, ok, "Read interface should return *common.MeteringData")
+		assert.Equal(t, testTimestamp, readData.Timestamp, "Interface read data timestamp mismatch")
+		assert.Equal(t, "storage", readData.Category, "Interface read data category mismatch")
+	}
+
+	// Test error cases
+	// Test reading non-existent file
+	_, err = meteringReader.ReadFile(context.Background(), "metering/ru/999999/nonexistent/test-0.json.gz")
+	assert.Error(t, err, "Should error when reading non-existent file")
+
+	// Test listing files for non-existent timestamp
+	emptyFiles, err := meteringReader.ListFilesByTimestamp(context.Background(), 999999)
+	assert.NoError(t, err, "Should not error when listing non-existent timestamp")
+	assert.Equal(t, int64(999999), emptyFiles.Timestamp, "Empty timestamp should match")
+	assert.Equal(t, 0, len(emptyFiles.Files), "Should have no files for non-existent timestamp")
+
+	// Test GetFileInfo with invalid path
+	_, err = meteringReader.GetFileInfo("invalid/path")
+	assert.Error(t, err, "Should error for invalid file path")
+
+	t.Logf("Metering reader test passed. Files found: compute=%d, storage=%d", 
+		len(computeFiles), len(storageFiles))
+}
+
+func TestMeteringReadWriteRoundtripWithLocalFS(t *testing.T) {
+	// Create temporary directory
+	tempDir := filepath.Join(os.TempDir(), "tidb-metering-test", "roundtrip")
+	defer os.RemoveAll(tempDir)
+
+	// Create configuration
+	cfg := config.DefaultConfig()
+	providerConfig := &storage.ProviderConfig{
+		Type: storage.ProviderTypeLocalFS,
+		LocalFS: &storage.LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	// Create storage provider
+	provider, err := storage.NewObjectStorageProvider(providerConfig)
+	assert.NoError(t, err, "Failed to create LocalFS provider")
+
+	// Create writer and reader
+	meteringWriter := meteringwriter.NewMeteringWriter(provider, cfg)
+	defer meteringWriter.Close()
+	meteringReader := meteringreader.NewMeteringReader(provider, cfg)
+
+	// Test multiple timestamps and categories
+	testCases := []struct {
+		timestamp int64
+		category  string
+		selfID    string
+		data      []map[string]interface{}
+	}{
+		{
+			timestamp: 1640995200, // 2022-01-01 00:00:00
+			category:  "compute",
+			selfID:    "tidb001",
+			data: []map[string]interface{}{
+				{
+					"logical_cluster": "production",
+					"cpu_cores":       &common.MeteringValue{Value: 16, Unit: "cores"},
+					"memory_gb":       &common.MeteringValue{Value: 64, Unit: "GB"},
+				},
+			},
+		},
+		{
+			timestamp: 1640995200,
+			category:  "storage",
+			selfID:    "tikv001",
+			data: []map[string]interface{}{
+				{
+					"logical_cluster": "production",
+					"disk_size":       &common.MeteringValue{Value: 1000, Unit: "GB"},
+					"iops":           &common.MeteringValue{Value: 5000, Unit: "ops/s"},
+				},
+			},
+		},
+		{
+			timestamp: 1640995260, // 1 minute later
+			category:  "compute",
+			selfID:    "tidb001",
+			data: []map[string]interface{}{
+				{
+					"logical_cluster": "production",
+					"cpu_cores":       &common.MeteringValue{Value: 16, Unit: "cores"},
+					"memory_gb":       &common.MeteringValue{Value: 64, Unit: "GB"},
+				},
+				{
+					"logical_cluster": "development",
+					"cpu_cores":       &common.MeteringValue{Value: 4, Unit: "cores"},
+					"memory_gb":       &common.MeteringValue{Value: 16, Unit: "GB"},
+				},
+			},
+		},
+	}
+
+	// Write all test data
+	writtenFiles := make(map[string]*common.MeteringData)
+	for _, tc := range testCases {
+		testData := &common.MeteringData{
+			Timestamp: tc.timestamp,
+			Category:  tc.category,
+			SelfID:    tc.selfID,
+			Data:      tc.data,
+		}
+
+		err = meteringWriter.Write(context.Background(), testData)
+		assert.NoError(t, err, "Failed to write test data for %s/%s", tc.category, tc.selfID)
+
+		// Expected file path for verification
+		expectedPath := fmt.Sprintf("metering/ru/%d/%s/%s-0.json.gz",
+			tc.timestamp, tc.category, tc.selfID)
+		writtenFiles[expectedPath] = testData
+	}
+
+	// Test reading all written files
+	for filePath, originalData := range writtenFiles {
+		t.Run(fmt.Sprintf("read_%s", filePath), func(t *testing.T) {
+			// Verify file exists
+			exists, err := provider.Exists(context.Background(), filePath)
+			assert.NoError(t, err, "Failed to check if file exists")
+			assert.True(t, exists, "File should exist: %s", filePath)
+
+			// Read via reader
+			readData, err := meteringReader.ReadFile(context.Background(), filePath)
+			assert.NoError(t, err, "Failed to read file: %s", filePath)
+
+			// Verify metadata
+			assert.Equal(t, originalData.Timestamp, readData.Timestamp, "Timestamp mismatch")
+			assert.Equal(t, originalData.Category, readData.Category, "Category mismatch")
+			assert.Equal(t, originalData.SelfID, readData.SelfID, "SelfID mismatch")
+			assert.Equal(t, len(originalData.Data), len(readData.Data), "Data entries count mismatch")
+
+			// Verify data content
+			for i, originalEntry := range originalData.Data {
+				readEntry := readData.Data[i]
+				assert.Equal(t, originalEntry["logical_cluster"], readEntry["logical_cluster"],
+					"Logical cluster mismatch in entry %d", i)
+
+				// Check all metering values
+				for key, originalValue := range originalEntry {
+					if key == "logical_cluster" {
+						continue // Already checked
+					}
+
+					if originalMV, ok := originalValue.(*common.MeteringValue); ok {
+						readValue, ok := readEntry[key].(map[string]interface{})
+						assert.True(t, ok, "Expected map[string]interface{} for key %s", key)
+						// JSON unmarshaling converts numbers to float64, so we need to compare accordingly
+						expectedValue := float64(originalMV.Value)
+						assert.Equal(t, expectedValue, readValue["value"], "Value mismatch for %s", key)
+						assert.Equal(t, originalMV.Unit, readValue["unit"], "Unit mismatch for %s", key)
+					}
+				}
+			}
+		})
+	}
+
+	// Test listing files by timestamp
+	uniqueTimestamps := make(map[int64]bool)
+	for _, tc := range testCases {
+		uniqueTimestamps[tc.timestamp] = true
+	}
+
+	for timestamp := range uniqueTimestamps {
+		t.Run(fmt.Sprintf("list_timestamp_%d", timestamp), func(t *testing.T) {
+			timestampFiles, err := meteringReader.ListFilesByTimestamp(context.Background(), timestamp)
+			assert.NoError(t, err, "Failed to list files for timestamp %d", timestamp)
+			assert.Equal(t, timestamp, timestampFiles.Timestamp, "Timestamp mismatch")
+
+			// Count expected files for this timestamp
+			expectedCategories := make(map[string]int)
+			for _, tc := range testCases {
+				if tc.timestamp == timestamp {
+					expectedCategories[tc.category]++
+				}
+			}
+
+			// Verify categories exist
+			for expectedCategory := range expectedCategories {
+				assert.Contains(t, timestampFiles.Files, expectedCategory,
+					"Category %s should exist for timestamp %d", expectedCategory, timestamp)
+				assert.Greater(t, len(timestampFiles.Files[expectedCategory]), 0,
+					"Category %s should have files for timestamp %d", expectedCategory, timestamp)
+			}
+		})
+	}
+
+	t.Logf("Metering read-write roundtrip test completed successfully")
+}
+
+func TestMetaReaderWithLocalFS(t *testing.T) {
+	// Create temporary directory
+	tempDir := filepath.Join(os.TempDir(), "tidb-metering-test", "meta-reader")
+	defer os.RemoveAll(tempDir)
+
+	// Create configuration
+	cfg := config.DefaultConfig()
+	providerConfig := &storage.ProviderConfig{
+		Type: storage.ProviderTypeLocalFS,
+		LocalFS: &storage.LocalFSConfig{
+			BasePath:   tempDir,
+			CreateDirs: true,
+		},
+	}
+
+	// Create storage provider
+	provider, err := storage.NewObjectStorageProvider(providerConfig)
+	assert.NoError(t, err, "Failed to create LocalFS provider")
+
+	// First write some test data using the writer
+	metaWriter := metawriter.NewMetaWriter(provider, cfg)
+	defer metaWriter.Close()
+
+	// Create test metadata
+	testClusterID := "test-cluster-001"
+	testTimestamp := time.Now().Unix()
+	testMetadata := &common.MetaData{
+		ClusterID: testClusterID,
+		ModifyTS:  testTimestamp,
+		Metadata: map[string]interface{}{
+			"version":      "v6.5.0",
+			"node_count":   5,
+			"region":       "us-west-2",
+			"environment":  "production",
+			"capabilities": []string{"ACID", "TiFlash", "TiCDC"},
+		},
+	}
+
+	// Write test metadata
+	err = metaWriter.Write(context.Background(), testMetadata)
+	assert.NoError(t, err, "Failed to write test metadata")
+
+	// Write another metadata with different timestamp
+	testMetadata2 := &common.MetaData{
+		ClusterID: testClusterID,
+		ModifyTS:  testTimestamp + 60, // 1 minute later
+		Metadata: map[string]interface{}{
+			"version":      "v6.5.1",
+			"node_count":   6,
+			"region":       "us-west-2",
+			"environment":  "production",
+			"capabilities": []string{"ACID", "TiFlash", "TiCDC", "TiDB Lightning"},
+		},
+	}
+
+	err = metaWriter.Write(context.Background(), testMetadata2)
+	assert.NoError(t, err, "Failed to write second test metadata")
+
+	// Now test the reader
+	metaReader, err := metareader.NewMetaReader(provider, cfg, nil)
+	assert.NoError(t, err, "Failed to create meta reader")
+
+	// Test Read - read metadata by cluster ID and timestamp  
+	firstMeta, err := metaReader.Read(context.Background(), testClusterID, testTimestamp)
+	assert.NoError(t, err, "Failed to read metadata by timestamp")
+	assert.NotNil(t, firstMeta, "First metadata should not be nil")
+	assert.Equal(t, testClusterID, firstMeta.ClusterID, "Cluster ID mismatch")
+	assert.Equal(t, testTimestamp, firstMeta.ModifyTS, "Timestamp should match")
+	assert.Equal(t, "v6.5.0", firstMeta.Metadata["version"], "Version should be the first one")
+	assert.Equal(t, float64(5), firstMeta.Metadata["node_count"], "Node count should be the first one")
+
+	// Test Read with second timestamp
+	secondMeta, err := metaReader.Read(context.Background(), testClusterID, testTimestamp+60)
+	assert.NoError(t, err, "Failed to read second metadata")
+	assert.NotNil(t, secondMeta, "Second metadata should not be nil")
+	assert.Equal(t, testClusterID, secondMeta.ClusterID, "Cluster ID mismatch")
+	assert.Equal(t, testTimestamp+60, secondMeta.ModifyTS, "Timestamp should match")
+	assert.Equal(t, "v6.5.1", secondMeta.Metadata["version"], "Version should be the second one")
+	assert.Equal(t, float64(6), secondMeta.Metadata["node_count"], "Node count should be the second one")
+
+	// Test ReadFile (interface method)
+	expectedPath := fmt.Sprintf("metering/meta/%s/%d.json.gz", testClusterID, testTimestamp)
+	readInterface, err := metaReader.ReadFile(context.Background(), expectedPath)
+	assert.NoError(t, err, "Failed to read via ReadFile")
+	readMeta, ok := readInterface.(*common.MetaData)
+	assert.True(t, ok, "ReadFile should return *common.MetaData")
+	assert.Equal(t, testClusterID, readMeta.ClusterID, "ReadFile cluster ID mismatch")
+	assert.Equal(t, testTimestamp, readMeta.ModifyTS, "ReadFile timestamp mismatch")
+
+	// Test error cases
+	// Test reading non-existent cluster/timestamp combination
+	_, err = metaReader.Read(context.Background(), "non-existent-cluster", testTimestamp)
+	assert.Error(t, err, "Should error when reading non-existent cluster")
+
+	// Test reading non-existent timestamp for existing cluster
+	_, err = metaReader.Read(context.Background(), testClusterID, 999999)
+	assert.Error(t, err, "Should error when reading non-existent timestamp")
+
+	// Test ReadFile with non-existent path
+	_, err = metaReader.ReadFile(context.Background(), "metering/meta/non-existent/999999.json.gz")
+	assert.Error(t, err, "Should error when reading non-existent file")
+
+	t.Logf("Meta reader test passed. Cluster: %s, Timestamps: [%d, %d]", 
+		testClusterID, testTimestamp, testTimestamp+60)
 }


### PR DESCRIPTION
fix local fs read failed if set perfix
```
localConfig := &storage.ProviderConfig{
		Type: storage.ProviderTypeLocalFS,
		LocalFS: &storage.LocalFSConfig{
			BasePath:   dir,
			CreateDirs: true,
		},
		Prefix: "test",
	}
```
failed with
```
// Check if matches prefix
		if strings.HasPrefix(relPath, prefix) {
			// Use forward slash as path separator consistently, same as cloud storage
			normalizedPath := strings.ReplaceAll(relPath, string(filepath.Separator), "/")
			files = append(files, normalizedPath)
		}
```